### PR TITLE
Stops exceptions when the environment is not present in the yml file.

### DIFF
--- a/lib/envyable/loader.rb
+++ b/lib/envyable/loader.rb
@@ -30,6 +30,7 @@ module Envyable
     # Returns nothing.
     def load(environment='development')
       if @yml ||= load_yml
+        return unless @yml[environment]
         @yml[environment].each { |key, value| set_value(key, value) }
       end
     end

--- a/spec/envyable_spec.rb
+++ b/spec/envyable_spec.rb
@@ -15,5 +15,9 @@ describe Envyable do
     it 'should not fail if file is not there' do
       Envyable.load 'spec/fixtures/nothing.yml'
     end
+
+    it 'should not fail if the environment is not represented in the file' do
+      Envyable.load 'spec/fixtures/env.yml', 'production'
+    end
   end
 end


### PR DESCRIPTION
When the environment yml file is missing the environment that the app is running in, the gem would throw an exception and stop the app loading. I feel that failing silently in this case is better as the issue is that ENV vars are missing in the environment, but this shouldn't stop an app from loading.

This was a particular pain when using pow as the failed app just left pow trying to start it but failing really slowly.
