### PR TITLE
Adding Spring watch setup to install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,24 @@ $ envyable install
 ```
 
 and you will get a `config` directory containing an `env.yml` and a
-`env.yml.example` file. If you have a `.gitignore` file this will also append
-the line
+`env.yml.example` file. If you have a `.gitignore` file, this will also append
+the line:
 
 ```yaml
 /config/env.yml
 ```
 
 to your config so that you do not check in `/config/env.yml`.
+
+If you have [Spring](https://github.com/rails/spring) bundled with your
+application, this will append the following line to `/config/spring.rb`:
+
+```ruby
+Spring.watch 'config/env.yml'
+```
+
+If the file `/config/spring.rb` does not exist, it will be created.
+
 
 ## Usage
 
@@ -77,6 +87,10 @@ Envyable.load('config/env.yml')
 ### Version control
 
 It is not recommended that you check the yaml file in to version control. Personally, I like to check in a `env.yml.example` file that shows the required keys, but does not include any credentials.
+
+## Troubleshooting
+
+If your ENV values don't update when you modify `config/env.yml`, verify if you have Spring (or another application preloader) that isn't configured to watch and reload when you update values.  You should try configuring the preloader or just restarting it.
 
 ## Contributing
 

--- a/lib/envyable/cli.rb
+++ b/lib/envyable/cli.rb
@@ -15,6 +15,12 @@ module Envyable
           "\n# Don't check in credentials \nconfig/env.yml"
         end
       end
+      if File.exist?("#{destination_root}/bin/spring")
+        create_file("config/spring.rb") unless File.exist?("#{destination_root}/config/spring.rb")
+        append_to_file("config/spring.rb") do
+          "Spring.watch 'config/env.yml'"
+        end
+      end
     end
   end
 end

--- a/spec/envyable/cli_spec.rb
+++ b/spec/envyable/cli_spec.rb
@@ -38,5 +38,25 @@ describe Envyable::CLI do
       capture_io { cli.install }
       File.readlines(gitignore).any? { |line|  line == "config/env.yml" }.must_equal true
     end
+
+    it "should create a file in config/spring.rb if it doesn't exist already" do
+      spring_rb = "#{cli.destination_root}/config/spring.rb"
+      spring_bin = "#{cli.destination_root}/bin/spring"
+      unless File.exist?(spring_rb) || !File.exist?(spring_bin)
+        File.exist?(spring_rb).must_equal false
+        capture_io { cli.install }
+        File.exist?(spring_rb).must_equal true
+      end
+    end
+
+    it "should add config/env.yml to Spring's watch list" do
+      spring_rb = "#{cli.destination_root}/config/spring.rb"
+      spring_bin = "#{cli.destination_root}/bin/spring"
+      unless File.exist?(spring_rb) || !File.exist?(spring_bin)
+        File.readlines(spring_rb).none? { |line| line == "Spring.watch 'config/env.yml'" }.must_equal true
+        capture_io { cli.install }
+        File.readlines(spring_rb).any? { |line| line == "Spring.watch 'config/env.yml'" }.must_equal true
+      end
+    end
   end
 end


### PR DESCRIPTION
Spring, a common default gem in Rails, stealthily prevents Envyable from reloading from `config/env.yml` when restarting the Rails server or console.  This update checks for the presence of Spring and adds the line
```ruby
Spring.watch 'config/env.yml'
```
to `config/spring.rb`.  Also updated `README.md` to include this detail, and rspec tests to reflect new functionality.